### PR TITLE
Add docs about using DiscriminatedUnionConverter for F# unions

### DIFF
--- a/docs/fsharp.md
+++ b/docs/fsharp.md
@@ -20,6 +20,17 @@ VerifierSettings.AddExtraSettings(fun settings -> settings.NullValueHandling <- 
 <sup><a href='/src/FSharpTests/Tests.fs#L9-L11' title='Snippet source file'>snippet source</a> | <a href='#snippet-nullvaluehandling' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Discriminated unions
+
+Since version [19.7.0](https://github.com/VerifyTests/Verify/pull/767), the converter for F# discriminated unions is no longer added by default.  
+Without this converter, F# unions are serialized as empty objects since they use fields as their internal representation and fields are ignored by the serializer.
+
+To serialize F# unions properly, add the converter:
+
+```fs
+VerifierSettings.AddExtraSettings(fun settings -> settings.Converters.Add(Argon.DiscriminatedUnionConverter()))
+```
+
 
 ## Async Qwerks
 


### PR DESCRIPTION
It seems support for F# discriminated unions was dropped in version 19.7.0 with this PR: https://github.com/VerifyTests/Verify/pull/767

This breaks my tests since I'm using F# unions: the serializer now serializes the unions as empty objects by default.

I had to add back the converter myself to get the previous behaviour.

This PR documents this change.